### PR TITLE
feat: connect frontend to backend API with env-aware URL (#20)

### DIFF
--- a/smartchef-frontend/script.js
+++ b/smartchef-frontend/script.js
@@ -3,7 +3,25 @@
 // Issue #19: Saved recipes display
 // Issue #20: API integration
 
-const API_URL = 'http://localhost:8000'; // Change to deployed URL later
+// Auto-detect backend URL: use deployed URL in production, localhost in dev
+const API_URL = window.location.hostname === 'localhost'
+  ? 'http://localhost:8000'
+  : 'https://YOUR-DEPLOYED-BACKEND-URL.onrender.com'; // ← the real URL here
+
+
+// Check backend health on page load
+async function checkBackendHealth() {
+  try {
+    const res = await fetch(`${API_URL}/health`);
+    const data = await res.json();
+    if (data.status === 'OK') {
+      console.log('Backend connected ✅');
+    }
+  } catch (err) {
+    console.warn('Backend not reachable. Working in offline mode.');
+  }
+}
+checkBackendHealth();
 
 // ---- Ingredient list state ----
 let ingredients = [];


### PR DESCRIPTION
What this PR does: Makes the API URL environment-aware so the frontend automatically connects to localhost during development and to the deployed backend URL in production. Adds a health check on page load.
Closes #20

## Current Status
API integration complete (localhost:8000)
Render URL will be added after backend deployment

How to verify: Open the browser console when running locally — you should see "Backend connected " if the backend is running. On the deployed URL it should connect to the Render backend.
